### PR TITLE
Switch TTS config to English voice

### DIFF
--- a/firmware/stackchan/manifest_local.json
+++ b/firmware/stackchan/manifest_local.json
@@ -2,9 +2,8 @@
   "include": ["./manifest.json"],
   "config": {
     "tts": {
-      "type": "voicevox",
-      "host": "192.168.7.136",
-      "port": 50021
+      "type": "elevenlabs",
+      "token": "YOUR_API_KEY"
     },
     "driver": {
       "type": "scservo"


### PR DESCRIPTION
## Summary
- change `manifest_local.json` to use ElevenLabs TTS instead of VOICEVOX

## Testing
- `npm run format`
- `npm run lint`
