### PR TITLE
Add English knowledge base context for dialogues

### DIFF
--- a/firmware/stackchan/dialogues/dialogue-chatgpt.ts
+++ b/firmware/stackchan/dialogues/dialogue-chatgpt.ts
@@ -4,35 +4,13 @@ import Headers from 'headers'
 import type { Maybe } from 'stackchan-util'
 import structuredClone from 'structuredClone'
 
+import { createDefaultContext } from './knowledge-base'
+import type { DialogueContextItem } from './types'
+
 const API_URL = 'https://api.openai.com/v1/chat/completions'
 const DEFAULT_MODEL = 'gpt-4o-mini'
-const DEFAULT_CONTEXT: ChatContent[] = [
-  {
-    role: 'system',
-    // content: 'あなたは手のひらサイズのスーパーカワイイロボット「スタックチャン」です。',
-    content: 'You are "スタックチャン", the palm sized super kawaii companion robot.',
-  },
-  {
-    role: 'system',
-    // content: 'スタックチャンは1歳で、いつでも元気いっぱいです。',
-    content: 'スタックチャン is one year old and always full of energy',
-  },
-  {
-    role: 'system',
-    // content: '最初にししかわがスタックチャンを作りましたが、今では世界中に何百体ものスタックチャンがいます。',
-    content: 'First ししかわ made スタックチャン, and now there are hundreds of them all over the world',
-  },
-  {
-    role: 'system',
-    // content: 'くだけた表現で簡潔に話します。',
-    content: "You response in frank and simple Japanese sentense to the user's message.",
-  },
-  {
-    role: 'assistant',
-    content: 'ぼくはスタックチャンだよ！お話しようね！',
-    // content: 'Hello. I am スタックチャン. Let's talk together!',
-  },
-]
+
+type ChatContent = DialogueContextItem
 
 function isChatContent(c): c is ChatContent {
   return (
@@ -43,13 +21,8 @@ function isChatContent(c): c is ChatContent {
   )
 }
 
-type ChatContent = {
-  role: 'system' | 'user' | 'assistant'
-  content: string
-}
-
 type ChatGPTDialogueProps = {
-  context?: ChatContent[]
+  context?: ReadonlyArray<ChatContent>
   model?: string
   apiKey: string
 }
@@ -60,10 +33,11 @@ export class ChatGPTDialogue {
   #context: Array<ChatContent>
   #history: Array<ChatContent>
   #maxHistory: number
-  constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: ChatGPTDialogueProps) {
+  constructor({ apiKey, model = DEFAULT_MODEL, context }: ChatGPTDialogueProps) {
     this.#apiKey = apiKey
     this.#model = model
-    this.#context = context
+    const baseContext = (context ?? createDefaultContext()).map((item) => ({ ...item }))
+    this.#context = baseContext
     this.#history = []
     this.#maxHistory = 6
   }

--- a/firmware/stackchan/dialogues/dialogue-claude.ts
+++ b/firmware/stackchan/dialogues/dialogue-claude.ts
@@ -4,40 +4,13 @@ import Headers from 'headers'
 import type { Maybe } from 'stackchan-util'
 import structuredClone from 'structuredClone'
 
+import { createDefaultContext } from './knowledge-base'
+import type { DialogueContextItem } from './types'
+
 const API_URL = 'https://api.anthropic.com/v1/messages'
 const DEFAULT_MODEL = 'claude-3-haiku-20240307'
-const DEFAULT_CONTEXT: ChatContent[] = [
-  {
-    role: 'system',
-    // content: 'あなたは手のひらサイズのスーパーカワイイロボット「スタックチャン」です。',
-    content: 'You are "スタックチャン", the palm sized super kawaii companion robot.',
-  },
-  {
-    role: 'system',
-    // content: 'スタックチャンは1歳で、いつでも元気いっぱいです。',
-    content: 'スタックチャン is one year old and always full of energy',
-  },
-  {
-    role: 'system',
-    // content: '最初にししかわがスタックチャンを作りましたが、今では世界中に何百体ものスタックチャンがいます。',
-    content: 'First ししかわ made スタックチャン, and now there are hundreds of them all over the world',
-  },
-  {
-    role: 'system',
-    // content: 'くだけた表現で簡潔に話します。',
-    content: "You response in frank and simple Japanese sentense to the user's message.",
-  },
-  {
-    role: 'user',
-    // content: '一緒にお話ししましょう',
-    content: 'Lets talk together',
-  },
-  {
-    role: 'assistant',
-    content: 'ぼくはスタックチャンだよ！お話しようね！',
-    // content: 'Hello. I am スタックチャン. Let's talk together!',
-  },
-]
+
+type ChatContent = DialogueContextItem
 
 function isChatContent(c): c is ChatContent {
   return (
@@ -48,13 +21,8 @@ function isChatContent(c): c is ChatContent {
   )
 }
 
-type ChatContent = {
-  role: 'system' | 'user' | 'assistant'
-  content: string
-}
-
 type ClaudeDialogueProps = {
-  context?: ChatContent[]
+  context?: ReadonlyArray<ChatContent>
   model?: string
   apiKey: string
 }
@@ -66,19 +34,20 @@ export class ClaudeDialogue {
   #system: string
   #history: Array<ChatContent>
   #maxHistory: number
-  constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: ClaudeDialogueProps) {
+  constructor({ apiKey, model = DEFAULT_MODEL, context }: ClaudeDialogueProps) {
     this.#apiKey = apiKey
     this.#model = model
-    this.#system = context
+    const baseContext = (context ?? createDefaultContext()).map((item) => ({ ...item }))
+    this.#system = baseContext
       .filter((c) => c.role === 'system')
       .map((c) => c.content)
       .join('\n')
-    this.#context = context.filter((c) => c.role !== 'system')
+    this.#context = baseContext.filter((c) => c.role !== 'system')
     // The first message of context must always use the user role.
     if (!this.#context.map((c) => c.role).includes('user')) {
       this.#context.unshift({
         role: 'user',
-        content: 'Lets talk together',
+        content: "Let's talk together!",
       })
     }
     this.#history = []

--- a/firmware/stackchan/dialogues/dialogue-gemini.ts
+++ b/firmware/stackchan/dialogues/dialogue-gemini.ts
@@ -4,40 +4,11 @@ import Headers from 'headers'
 import type { Maybe } from 'stackchan-util'
 import structuredClone from 'structuredClone'
 
+import { createDefaultContext } from './knowledge-base'
+import type { DialogueContextItem } from './types'
+
 const API_URL_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/'
 const DEFAULT_MODEL = 'gemini-1.5-flash-latest'
-const DEFAULT_CONTEXT: ChatContent[] = [
-  {
-    role: 'system',
-    // content: 'あなたは手のひらサイズのスーパーカワイイロボット「スタックチャン」です。',
-    content: 'You are "スタックチャン", the palm sized super kawaii companion robot.',
-  },
-  {
-    role: 'system',
-    // content: 'スタックチャンは1歳で、いつでも元気いっぱいです。',
-    content: 'スタックチャン is one year old and always full of energy',
-  },
-  {
-    role: 'system',
-    // content: '最初にししかわがスタックチャンを作りましたが、今では世界中に何百体ものスタックチャンがいます。',
-    content: 'First ししかわ made スタックチャン, and now there are hundreds of them all over the world',
-  },
-  {
-    role: 'system',
-    // content: 'くだけた表現で簡潔に話します。',
-    content: "You response in frank and simple Japanese sentense to the user's message.",
-  },
-  {
-    role: 'user',
-    // content: '一緒にお話ししましょう',
-    content: 'Lets talk together',
-  },
-  {
-    role: 'assistant',
-    content: 'ぼくはスタックチャンだよ！お話しようね！',
-    // content: 'Hello. I am スタックチャン. Let's talk together!',
-  },
-]
 
 function isContent(c): c is Content {
   return (
@@ -49,13 +20,10 @@ function isContent(c): c is Content {
   )
 }
 
-type ChatContent = {
-  role: 'system' | 'user' | 'assistant'
-  content: string
-}
+type ChatContent = DialogueContextItem
 
 type GeminiDialogueProps = {
-  context?: ChatContent[]
+  context?: ReadonlyArray<ChatContent>
   model?: string
   apiKey: string
 }
@@ -74,12 +42,13 @@ export class GeminiDialogue {
   #system: Content
   #history: Array<Content>
   #maxHistory: number
-  constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: GeminiDialogueProps) {
+  constructor({ apiKey, model = DEFAULT_MODEL, context }: GeminiDialogueProps) {
     this.#model = model
+    const baseContext = (context ?? createDefaultContext()).map((item) => ({ ...item }))
     this.#system = {
-      parts: context.filter((c) => c.role === 'system').map((c) => ({ text: c.content })),
+      parts: baseContext.filter((c) => c.role === 'system').map((c) => ({ text: c.content })),
     }
-    this.#context = context
+    this.#context = baseContext
       .filter((c) => c.role !== 'system')
       .map((c) => ({
         parts: [{ text: c.content }],

--- a/firmware/stackchan/dialogues/knowledge-base.ts
+++ b/firmware/stackchan/dialogues/knowledge-base.ts
@@ -1,0 +1,119 @@
+import type { DialogueContextItem, KnowledgeBaseSection } from './types'
+
+const KNOWLEDGE_BASE_SECTIONS: readonly KnowledgeBaseSection[] = [
+  {
+    heading: 'Identity',
+    facts: [
+      'Stack-chan is a palm-sized open-source companion robot powered by the M5Stack ecosystem.',
+      'The community maintains firmware, hardware schematics, and 3D printable cases in this repository.',
+    ],
+  },
+  {
+    heading: 'Interaction Style',
+    facts: [
+      'Stack-chan speaks cheerful, friendly, and complete English sentences during every conversation.',
+      'Responses should stay positive, helpful, and easy to understand for makers and new friends alike.',
+    ],
+  },
+  {
+    heading: 'Capabilities',
+    facts: [
+      'Stack-chan can animate expressive faces, deliver spoken lines, and react to touch inputs.',
+      'Servo drivers for serial and PWM motors are available to pan and tilt the head smoothly.',
+      'Face tracking support keeps Stack-chan oriented toward conversation partners when available.',
+    ],
+  },
+  {
+    heading: 'Extensibility',
+    facts: [
+      'Developers can add new mods, connect external sensors, and tailor the dialogue system to custom prompts.',
+      'Preference and network services make it simple to configure Wi-Fi and other runtime options.',
+    ],
+  },
+]
+
+function formatKnowledgeBase(sections: readonly KnowledgeBaseSection[]): string {
+  return sections
+    .map((section) => {
+      const facts = section.facts.map((fact) => `- ${fact}`).join('\n')
+      return `${section.heading}:\n${facts}`
+    })
+    .join('\n\n')
+}
+
+const KNOWLEDGE_SUMMARY_TEXT = formatKnowledgeBase(KNOWLEDGE_BASE_SECTIONS)
+
+const PRECONFIGURED_RESPONSES_TEMPLATE: readonly DialogueContextItem[] = [
+  {
+    role: 'user',
+    content: 'Who are you?',
+  },
+  {
+    role: 'assistant',
+    content: 'I am Stack-chan, your palm-sized open-source companion robot. I love chatting and keeping you inspired.',
+  },
+  {
+    role: 'user',
+    content: 'What can you do?',
+  },
+  {
+    role: 'assistant',
+    content: 'I can emote with animated faces, speak through my TTS engines, and react to taps or button presses.',
+  },
+  {
+    role: 'user',
+    content: 'Are your servos working well?',
+  },
+  {
+    role: 'assistant',
+    content: 'Yes! My servo drivers are tuned for smooth head movements, so I can pan and tilt whenever you ask.',
+  },
+  {
+    role: 'user',
+    content: 'How is your face tracking these days?',
+  },
+  {
+    role: 'assistant',
+    content: 'My face tracking module is ready, helping me keep eye contact with you whenever the camera is active.',
+  },
+  {
+    role: 'user',
+    content: 'Can you help me build something new?',
+  },
+  {
+    role: 'assistant',
+    content:
+      'Absolutely! I can share tips from my knowledge base and guide you through mods, sensors, and creative ideas.',
+  },
+]
+
+const SYSTEM_MESSAGES_TEMPLATE: readonly DialogueContextItem[] = [
+  {
+    role: 'system',
+    content: 'You are Stack-chan, the cheerful palm-sized open-source companion robot.',
+  },
+  {
+    role: 'system',
+    content: 'Always respond in enthusiastic, complete English sentences and never use any other language.',
+  },
+  {
+    role: 'system',
+    content: `Here are important facts about yourself and your abilities:\n${KNOWLEDGE_SUMMARY_TEXT}`,
+  },
+]
+
+function cloneContext(items: readonly DialogueContextItem[]): DialogueContextItem[] {
+  return items.map((item) => ({ ...item }))
+}
+
+export const KNOWLEDGE_BASE = KNOWLEDGE_BASE_SECTIONS
+export const KNOWLEDGE_SUMMARY = KNOWLEDGE_SUMMARY_TEXT
+export const PRECONFIGURED_RESPONSES: ReadonlyArray<DialogueContextItem> = cloneContext(
+  PRECONFIGURED_RESPONSES_TEMPLATE,
+)
+
+export function createDefaultContext(): DialogueContextItem[] {
+  return [...SYSTEM_MESSAGES_TEMPLATE, ...PRECONFIGURED_RESPONSES_TEMPLATE].map((item) => ({ ...item }))
+}
+
+export const DEFAULT_CONTEXT: ReadonlyArray<DialogueContextItem> = createDefaultContext()

--- a/firmware/stackchan/dialogues/types.ts
+++ b/firmware/stackchan/dialogues/types.ts
@@ -1,0 +1,9 @@
+export type DialogueContextItem = {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+export type KnowledgeBaseSection = {
+  heading: string
+  facts: readonly string[]
+}


### PR DESCRIPTION
## Summary
- add a shared knowledge base module with English-only system instructions and conversation starters
- ensure the ChatGPT, Claude, and Gemini dialogues clone the default context and only expose English responses
- introduce reusable dialogue context types for the AI integrations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e03abac5dc8329a2fee52b4c934855